### PR TITLE
Fixed autocleaning when pixi is ran again on a ROM which was previously applied with an empty list.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ asm/uninstall.asm
 asm/overworld.asm
 pixi*.zip
 .vscode
+make.bat

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ asm/overworld.asm
 pixi*.zip
 .vscode
 make.bat
+*.bat

--- a/_pixi.bat
+++ b/_pixi.bat
@@ -1,2 +1,2 @@
-pixi.exe -d -k test/test.smc
+pixi.exe -d -k -pl test/test.smc
 @pause

--- a/src/file_io.cpp
+++ b/src/file_io.cpp
@@ -21,6 +21,9 @@ unsigned char* read_all(const char *file_name, bool text_mode, unsigned int mini
 	FILE *file = open(file_name, "rb");
 	unsigned int size = file_size(file);
 	unsigned char *file_data = new unsigned char[(size < minimum_size ? minimum_size : size) + (text_mode * 2)]();
+	if (file_size == 0) {
+		error("%s was empty",file_name); 					//if file is empty, don't bother doing anything to the rom
+	}
 	if(fread(file_data, 1, size, file) != size){
 		error("%s could not be fully read.  Please check file permissions.", file_name);
 	}

--- a/src/file_io.cpp
+++ b/src/file_io.cpp
@@ -21,7 +21,7 @@ unsigned char* read_all(const char *file_name, bool text_mode, unsigned int mini
 	FILE *file = open(file_name, "rb");
 	unsigned int size = file_size(file);
 	unsigned char *file_data = new unsigned char[(size < minimum_size ? minimum_size : size) + (text_mode * 2)]();
-	if (file_size == 0) {
+	if (size == 0) {
 		error("%s was empty",file_name); 					//if file is empty, don't bother doing anything to the rom
 	}
 	if(fread(file_data, 1, size, file) != size){

--- a/src/file_io.cpp
+++ b/src/file_io.cpp
@@ -1,7 +1,6 @@
 #include <stdio.h>
 #include <string.h>
 #include "file_io.h"
-
 FILE *open(const char *name, const char *mode) {
 	FILE *file = fopen(name, mode);
 	if(!file){
@@ -17,10 +16,13 @@ int file_size(FILE *file) {
 	return size;
 }
 
-unsigned char* read_all(const char *file_name, bool text_mode, unsigned int minimum_size) {
+unsigned char* read_all(const char *file_name, bool text_mode, unsigned int minimum_size, FILE *output) {
 	FILE *file = open(file_name, "rb");
 	unsigned int size = file_size(file);
-	unsigned char *file_data = new unsigned char[(size < minimum_size ? minimum_size : size) + (text_mode * 2)]();
+	int size_used = (size < minimum_size ? minimum_size : size);
+	unsigned char *file_data = new unsigned char[size_used + (text_mode * 2)]();
+	if (strstr(file_name,"list.txt")!=nullptr && output == stdout)
+		fprintf(output,"Opened file list.txt\nminimum size is: %d\n%d size of array file_data\n",minimum_size,size_used);
 	if (size == 0) {
 		error("%s was empty.\n",file_name); 					//if file is empty, don't bother doing anything to the rom
 	}

--- a/src/file_io.cpp
+++ b/src/file_io.cpp
@@ -23,9 +23,6 @@ unsigned char* read_all(const char *file_name, bool text_mode, unsigned int mini
 	unsigned char *file_data = new unsigned char[size_used + (text_mode * 2)]();
 	if (strstr(file_name,"list.txt")!=nullptr && output == stdout)
 		fprintf(output,"Opened file list.txt\nminimum size is: %d\n%d size of array file_data\n",minimum_size,size_used);
-	if (size == 0) {
-		error("%s was empty.\n",file_name); 					//if file is empty, don't bother doing anything to the rom
-	}
 	if(fread(file_data, 1, size, file) != size){
 		error("%s could not be fully read.  Please check file permissions.", file_name);
 	}

--- a/src/file_io.cpp
+++ b/src/file_io.cpp
@@ -22,7 +22,7 @@ unsigned char* read_all(const char *file_name, bool text_mode, unsigned int mini
 	unsigned int size = file_size(file);
 	unsigned char *file_data = new unsigned char[(size < minimum_size ? minimum_size : size) + (text_mode * 2)]();
 	if (size == 0) {
-		error("%s was empty",file_name); 					//if file is empty, don't bother doing anything to the rom
+		error("%s was empty.\n",file_name); 					//if file is empty, don't bother doing anything to the rom
 	}
 	if(fread(file_data, 1, size, file) != size){
 		error("%s could not be fully read.  Please check file permissions.", file_name);

--- a/src/file_io.h
+++ b/src/file_io.h
@@ -12,7 +12,7 @@ void error(const char *message, A... args) {
 
 FILE *open(const char *name, const char *mode);
 int file_size(FILE *file);
-unsigned char* read_all(const char *file_name, bool text_mode = false, unsigned int minimum_size = 0u);
+unsigned char* read_all(const char *file_name, bool text_mode = false, unsigned int minimum_size = 0u, FILE *output = nullptr);
 void write_all(unsigned char *data, const char *file_name, unsigned int size);
 void write_all(unsigned char *data, const char* dir, const char *file_name, unsigned int size);
 

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -250,16 +250,22 @@ void clean_hack(ROM &rom)
 
 		//remove global sprites
 		fprintf(clean_patch, ";Global sprites: \n");
-		int global_table_address = rom.pointer_snes(0x02FFEE).addr();
-		for (int table_offset = 11; table_offset < limit; table_offset += 0x10)
-		{
-			pointer main_pointer = rom.pointer_snes(global_table_address + table_offset);
-			if (!main_pointer.is_empty())
+		pointer global_table_pointer = rom.pointer_snes(0x02FFEE);
+		int global_table_address = global_table_pointer.addr();
+		// FILE *debug_out = fopen("debug_out.txt","w+");
+		// fprintf(debug_out,"Global table pointer: $%06X\n",global_table_address);
+		// fprintf(debug_out,"%d %d %d\n",global_table_pointer.bankbyte,global_table_pointer.highbyte,global_table_pointer.lowbyte);
+		// fprintf(debug_out,"$%06X\n",rom.pointer_snes(global_table_address).addr());
+		if (rom.pointer_snes(global_table_address).addr() != 0xFFFFFF) {
+			for (int table_offset = 11; table_offset < limit; table_offset += 0x10)
 			{
+				pointer main_pointer = rom.pointer_snes(global_table_address + table_offset);
+				if (!main_pointer.is_empty())
+				{
 				fprintf(clean_patch, "autoclean $%06X\n", main_pointer.addr());
+				}
 			}
 		}
-
 		//shared routines
 		fprintf(clean_patch, "\n\n;Routines:\n");
 		for (int i = 0; i < 100; i++)
@@ -502,9 +508,7 @@ bool populate_sprite_list(const char **paths, sprite **sprite_lists, const char 
 	{
 		level = 0x200;
 		sprite_list = sprite_lists[type];
-		if (line_number == 1 && type != Sprite)
-			ERROR("List file doesn't contain any normal sprites, aborting insertion...\n");
-		//maybe this will fix? if on the first line and type isn't normal sprites, just abort
+
 		//read line from list_data
 		current_line = static_cast<simple_string &&>(get_line(list_data, i));
 		i += current_line.length;

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -502,7 +502,9 @@ bool populate_sprite_list(const char **paths, sprite **sprite_lists, const char 
 	{
 		level = 0x200;
 		sprite_list = sprite_lists[type];
-
+		if (line_number == 1 && type != Sprite)
+			ERROR("List file doesn't contain any normal sprites, aborting insertion...\n");
+		//maybe this will fix? if on the first line and type isn't normal sprites, just abort
 		//read line from list_data
 		current_line = static_cast<simple_string &&>(get_line(list_data, i));
 		i += current_line.length;
@@ -519,9 +521,8 @@ bool populate_sprite_list(const char **paths, sprite **sprite_lists, const char 
 			SETTYPE(Extended)
 		if (!strcmp(current_line.data, "CLUSTER:"))
 			SETTYPE(Cluster)
-		if (line_number == 1 && type != Sprite)
-			ERROR("No normal sprites in the list, aborting insertion.\n");
-		//maybe this will fix? if on the first line and type isn't normal sprites, just abort
+
+		
 		//if(!strcmp(current_line.data, "OW:"))
 		//	SETTYPE(Overworld)
 

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -984,7 +984,7 @@ int main(int argc, char *argv[])
 	// regular stuff
 	//------------------------------------------------------------------------------------------
 	std::list<std::string> extraDefines = listExtraAsm(ASM_DIR_PATH + "/ExtraDefines");
-	populate_sprite_list(paths, sprites_list_list, (char *)read_all(paths[LIST], true), output);
+	populate_sprite_list(paths, sprites_list_list, (char *)read_all(paths[LIST], true,0,output), output);
 
 	clean_hack(rom);
 

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -483,7 +483,6 @@ bool populate_sprite_list(const char **paths, sprite **sprite_lists, const char 
 {
 	int line_number = 0, i = 0, bytes_read, sprite_id, level;
 	simple_string current_line;
-
 	ListType type = Sprite;
 	const char *dir = nullptr;
 	sprite *sprite_list = nullptr;
@@ -520,6 +519,9 @@ bool populate_sprite_list(const char **paths, sprite **sprite_lists, const char 
 			SETTYPE(Extended)
 		if (!strcmp(current_line.data, "CLUSTER:"))
 			SETTYPE(Cluster)
+		if (line_number == 1 && type != Sprite)
+			ERROR("No normal sprites in the list, aborting insertion.\n");
+		//maybe this will fix? if on the first line and type isn't normal sprites, just abort
 		//if(!strcmp(current_line.data, "OW:"))
 		//	SETTYPE(Overworld)
 


### PR DESCRIPTION
Ignore the previous commits, those where useless workarounds and got deleted.