### PR TITLE
Minor sprite types implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ pixi*.zip
 make_modern.bat
 pixi
 build
+.idea

--- a/asm/bounce.asm
+++ b/asm/bounce.asm
@@ -1,0 +1,46 @@
+; implementation made by lx5
+
+incsrc "sa1def.asm"
+incsrc "pointer_caller.asm"
+
+org $029054|!BankB
+    autoclean JML Main
+    dl Ptr
+    warnpc $02905E|!BankB
+
+; Fixes the bug where hitting a block under a coin
+; will leave an invisible solid block in place of the coin
+org $029347            
+    JSR coin_fix
+    
+org $02D51E
+coin_fix:
+    LDA #$02
+    JMP $91BA
+
+freecode
+
+Main:
+    BNE .execute
+    LDY !bounce_timer,x
+    BEQ .execute
+    DEC !bounce_timer,x
+.execute
+    CMP.b #!BounceOffset
+    BCC .original
+
+.custom
+    SEC 
+    SBC.b #!BounceOffset
+    AND #$3F
+    %CallSprite(Ptr)
+.return
+    JML $02904C|!BankB
+
+.original
+    JML $02905E|!BankB
+
+   
+;tool generated pointer table
+Ptr:
+    incbin "_BouncePtr.bin"

--- a/asm/minorextended.asm
+++ b/asm/minorextended.asm
@@ -1,0 +1,39 @@
+; implementation made by lx5
+
+incsrc "sa1def.asm"
+incsrc "pointer_caller.asm"
+
+org $028B6C|!BankB
+    autoclean JML Main
+    dl Ptr
+    warnpc $028B74|!BankB
+
+freecode
+
+Main:
+    BEQ .return                     ; original code
+
+    STX $1698|!addr                 ; store index if valid
+    CMP.b #!MinorExtendedOffset     ; check if custom
+    BCC .original
+
+.custom
+    SEC 
+    SBC.b #!MinorExtendedOffset     ; substract
+    AND #$3F                        ; self imposed limit
+    %CallSprite(Ptr)
+    JML $028B74|!BankB
+
+.original
+    PHK
+    PEA.w .return-1
+    PEA.w $B888                     ; call original code
+    JML $028B94|!BankB              ; jslrts because it calls ExecutePtr
+
+.return
+    JML $028B74|!BankB              ; both routines return
+                                    ; to the same place
+    
+;tool generated pointer table
+Ptr:
+    incbin "_MinorExtendedPtr.bin"

--- a/asm/sa1def.asm
+++ b/asm/sa1def.asm
@@ -120,6 +120,19 @@ endmacro
 !GenStart = $D0
 !ClusterOffset  = $09
 !ExtendedOffset = $13
+!MinorExtendedOffset = $0C
+!SmokeOffset = $06
+!SpinningCoinOffset = $02
+!BounceOffset = $08
+!ScoreOffset = $16
+;!QuakeOffset = $03
+
+!MinorExtendedSize = $0C
+!SmokeSize = $04
+!SpinningCoinSize = $04
+!BounceSize = $04
+!ScoreSize = $06
+;!QuakeSize = $04
 
 ;$9E,x =  ($B4)
 
@@ -183,6 +196,66 @@ endmacro
 %define_base2_address(extended_timer,$176F)
 %define_base2_address(extended_behind,$1779)
 
+;minor extended defines
+%define_base2_address(minor_extended_num,$17F0)
+%define_base2_address(minor_extended_y_low,$17FC)
+%define_base2_address(minor_extended_y_high,$1814)
+%define_base2_address(minor_extended_x_low,$1808)
+%define_base2_address(minor_extended_x_high,$18EA)
+%define_base2_address(minor_extended_x_speed,$182C)
+%define_base2_address(minor_extended_y_speed,$1820)
+%define_base2_address(minor_extended_x_fraction,$1844)
+%define_base2_address(minor_extended_y_fraction,$1838)
+%define_base2_address(minor_extended_timer,$1850)
+
+;smoke sprite defines
+%define_base2_address(smoke_num,$17C0)
+%define_base2_address(smoke_y_low,$17C4)
+%define_base2_address(smoke_x_low,$17C8)
+%define_base2_address(smoke_timer,$17CC)
+
+;spinning coin sprite defines
+%define_base2_address(spinning_coin_num,$17D0)
+%define_base2_address(spinning_coin_y_low,$17D4)
+%define_base2_address(spinning_coin_y_speed,$17D8)
+%define_base2_address(spinning_coin_y_bits,$17DC)
+%define_base2_address(spinning_coin_x_low,$17E0)
+%define_base2_address(spinning_coin_layer,$17E4)
+%define_base2_address(spinning_coin_y_high,$17E8)
+%define_base2_address(spinning_coin_x_high,$17EC)
+
+;score sprite defines
+%define_base2_address(score_num,$16E1)
+%define_base2_address(score_y_low,$16E7)
+%define_base2_address(score_x_low,$16ED)
+%define_base2_address(score_x_high,$16F3)
+%define_base2_address(score_y_high,$16F9)
+%define_base2_address(score_y_speed,$16FF)
+%define_base2_address(score_layer,$1705)
+
+;bounce sprite defines
+%define_base2_address(bounce_num,$1699)
+%define_base2_address(bounce_init,$169D)
+%define_base2_address(bounce_y_low,$16A1)
+%define_base2_address(bounce_x_low,$16A5)
+%define_base2_address(bounce_y_high,$16A9)
+%define_base2_address(bounce_x_high,$16AD)
+%define_base2_address(bounce_y_speed,$16B1)
+%define_base2_address(bounce_x_speed,$16B5)
+%define_base2_address(bounce_x_bits,$16B9)
+%define_base2_address(bounce_y_bits,$16BD)
+%define_base2_address(bounce_map16_tile,$16C1)
+%define_base2_address(bounce_timer,$16C5)
+%define_base2_address(bounce_table,$16C9)
+%define_base2_address(bounce_properties,$1901)
+
+;quake sprite defines
+; %define_base2_address(quake_num,$16CD)
+; %define_base2_address(quake_x_low,$16D1)
+; %define_base2_address(quake_x_high,$16D5)
+; %define_base2_address(quake_y_low,$16D9)
+; %define_base2_address(quake_y_high,$16DD)
+; %define_base2_address(quake_timer,$18F8)
 
 ;overworld defines
 ; %define_sprite_table(ow_num,     $0DE5, $3200)

--- a/asm/score.asm
+++ b/asm/score.asm
@@ -1,0 +1,36 @@
+; implementation made by lx5
+
+incsrc "sa1def.asm"
+incsrc "pointer_caller.asm"
+
+org $02ADBA|!BankB
+    autoclean JML Main
+    dl Ptr
+    warnpc $02ADC2|!BankB
+
+freecode
+
+Main:
+    LDA !score_num,x
+    BEQ .return
+    STX $15E9|!addr
+
+    CMP.b #!ScoreOffset
+    BCC .original
+
+.custom
+    SEC 
+    SBC.b #!ScoreOffset
+    AND #$1F
+    %CallSprite(Ptr)
+.return
+    JML $02ADC5|!BankB
+
+.original
+    JML $02ADC2|!BankB
+
+
+   
+;tool generated pointer table
+Ptr:
+    incbin "_ScorePtr.bin"

--- a/asm/smoke.asm
+++ b/asm/smoke.asm
@@ -1,0 +1,35 @@
+; implementation made by lx5
+
+incsrc "sa1def.asm"
+incsrc "pointer_caller.asm"
+
+org $0296C0|!BankB
+    autoclean JML Main
+    dl Ptr
+    warnpc $0296C7|!BankB
+
+freecode
+
+Main:
+    LDA !smoke_num,x
+    BEQ .return                     ; original code
+
+    CMP.b #!SmokeOffset             ; check if custom
+    BCC .original
+
+.custom
+    SEC 
+    SBC.b #!SmokeOffset             ; substract
+    AND #$1F                        ; self imposed limit
+    %CallSprite(Ptr)
+.return
+    JML $0296D7|!BankB              ; both routines return
+                                    ; to the same place
+ 
+.original
+    JML $0296C7|!BankB
+
+   
+;tool generated pointer table
+Ptr:
+    incbin "_SmokePtr.bin"

--- a/asm/spinningcoin.asm
+++ b/asm/spinningcoin.asm
@@ -1,0 +1,44 @@
+; implementation made by lx5
+
+incsrc "sa1def.asm"
+incsrc "pointer_caller.asm"
+
+org $0299D4|!BankB
+    autoclean JML Main
+    dl Ptr
+    warnpc $0299DC|!BankB
+
+org $028A7D|!BankB
+    autoclean JML Fix
+
+freecode
+
+Fix: 
+    JSL $05B34A|!BankB
+    LDA #$01
+    STA !spinning_coin_num,x
+    JML $028A84|!BankB
+
+Main:
+    LDA !spinning_coin_num,x
+    BEQ .return                     ; original code
+    STX $15E9|!addr
+
+    CMP.b #!SpinningCoinOffset      ; check if custom
+    BCC .original
+
+.custom
+    SEC 
+    SBC.b #!SpinningCoinOffset      ; substract
+    AND #$1F                        ; self imposed limit
+    %CallSprite(Ptr)
+.return
+    JML $0299DF|!BankB
+
+.original
+    JML $0299DC|!BankB
+
+   
+;tool generated pointer table
+Ptr:
+    incbin "_SpinningCoinPtr.bin"

--- a/cluster/_header.asm
+++ b/cluster/_header.asm
@@ -4,3 +4,50 @@ macro LDE()
 	LDA !cluster_num,y
 	AND #$80
 endmacro
+
+macro SetupCoords()	
+    lda !cluster_x_low,x
+    sta $04
+    lda !cluster_x_high,x
+    sta $05
+    lda !cluster_y_low,x
+    sta $06
+    lda !cluster_y_high,x
+    sta $07
+endmacro
+
+macro SpawnExtendedAlt()
+    xba
+    %SetupCoords()
+	%SpawnExtendedGeneric()
+endmacro
+
+macro SpawnSmokeAlt()
+    xba
+    %SetupCoords()
+	%SpawnSmokeGeneric()
+endmacro
+
+macro SpawnCluster()
+    xba
+    %SetupCoords()
+	%SpawnClusterGeneric()
+endmacro
+
+macro SpawnMinorExtended()
+    xba
+    %SetupCoords()
+	%SpawnMinorExtendedGeneric()
+endmacro
+
+macro SpawnSpinningCoin()
+    xba
+    %SetupCoords()
+	%SpawnSpinningCoinGeneric()
+endmacro
+
+macro SpawnScore()
+    xba
+    %SetupCoords()
+	%SpawnScoreGeneric()
+endmacro

--- a/extended/_header.asm
+++ b/extended/_header.asm
@@ -1,21 +1,68 @@
 @include
 
 macro Speed()
-   LDA #$00
-   %ExtendedSpeed()
+    LDA #$00
+    %ExtendedSpeed()
 endmacro
 
 macro SpeedNoGrav()
-   LDA #$01
-   %ExtendedSpeed()
+    LDA #$01
+    %ExtendedSpeed()
 endmacro
 
 macro SpeedX()
-   LDA #$02
-   %ExtendedSpeed()
+    LDA #$02
+    %ExtendedSpeed()
 endmacro
 
 macro SpeedY()
-   LDA #$03
-   %ExtendedSpeed()
+    LDA #$03
+    %ExtendedSpeed()
+endmacro
+
+macro SetupCoords()
+    lda !extended_x_low,x
+    sta $04
+    lda !extended_x_high,x
+    sta $05
+    lda !extended_y_low,x
+    sta $06
+    lda !extended_y_high,x
+    sta $07
+endmacro
+
+macro SpawnExtendedAlt()
+    xba
+    %SetupCoords()
+	%SpawnExtendedGeneric()
+endmacro
+
+macro SpawnSmokeAlt()
+    xba
+    %SetupCoords()
+	%SpawnSmokeGeneric()
+endmacro
+
+macro SpawnCluster()
+    xba
+    %SetupCoords()
+	%SpawnClusterGeneric()
+endmacro
+
+macro SpawnMinorExtended()
+    xba
+    %SetupCoords()
+	%SpawnMinorExtendedGeneric()
+endmacro
+
+macro SpawnSpinningCoin()
+    xba
+    %SetupCoords()
+	%SpawnSpinningCoinGeneric()
+endmacro
+
+macro SpawnScore()
+    xba
+    %SetupCoords()
+	%SpawnScoreGeneric()
 endmacro

--- a/misc_sprites/bounce/_header.asm
+++ b/misc_sprites/bounce/_header.asm
@@ -1,0 +1,78 @@
+@include
+
+macro RevertMap16()
+    lda !bounce_map16_tile,x
+    %BounceChangeMap16()
+endmacro
+
+macro InvisibleMap16()
+    lda #$09
+    %BounceChangeMap16()
+endmacro
+
+macro SetSpeed() 
+    %BounceSetSpeed()
+endmacro
+
+macro SetMarioSpeed()
+    %BounceSetMarioSpeed()
+endmacro
+
+macro UpdatePos()
+    %BounceUpdatePos()
+endmacro
+
+macro EraseCoinAbove()
+    phk
+    pea.w ?label-1
+    pea.w $B888
+    jml $029265|!BankB
+?label
+endmacro
+
+macro SetupCoords()
+    lda !bounce_x_low,x
+    sta $04
+    lda !bounce_x_high,x
+    sta $05
+    lda !bounce_y_low,x
+    sta $06
+    lda !bounce_y_high,x
+    sta $07
+endmacro
+
+macro SpawnExtendedAlt()
+    xba
+    %SetupCoords()
+    %SpawnExtendedGeneric()
+endmacro
+
+macro SpawnSmokeAlt()
+    xba
+    %SetupCoords()
+    %SpawnSmokeGeneric()
+endmacro
+
+macro SpawnCluster()
+    xba
+    %SetupCoords()
+    %SpawnClusterGeneric()
+endmacro
+
+macro SpawnMinorExtended()
+    xba
+    %SetupCoords()
+    %SpawnMinorExtendedGeneric()
+endmacro
+
+macro SpawnSpinningCoin()
+    xba
+    %SetupCoords()
+    %SpawnSpinningCoinGeneric()
+endmacro
+
+macro SpawnScore()
+    xba
+    %SetupCoords()
+    %SpawnScoreGeneric()
+endmacro

--- a/misc_sprites/minorextended/_header.asm
+++ b/misc_sprites/minorextended/_header.asm
@@ -1,0 +1,68 @@
+@include
+
+macro SpeedX()
+    lda #$00
+    %MinorExtendedSpeed()
+endmacro
+
+macro SpeedY()
+    lda #$02
+    %MinorExtendedSpeed()
+endmacro
+
+macro SpeedXFast()
+    lda #$01
+    %MinorExtendedSpeed()
+endmacro
+
+macro SpeedYFast()
+    lda #$03
+    %MinorExtendedSpeed()
+endmacro
+
+macro SetupCoords()
+    lda !minor_extended_x_low,x
+    sta $04
+    lda !minor_extended_x_high,x
+    sta $05
+    lda !minor_extended_y_low,x
+    sta $06
+    lda !minor_extended_y_high,x
+    sta $07
+endmacro
+
+macro SpawnExtendedAlt()
+    xba
+    %SetupCoords()
+    %SpawnExtendedGeneric()
+endmacro
+
+macro SpawnSmokeAlt()
+    xba
+    %SetupCoords()
+    %SpawnSmokeGeneric()
+endmacro
+
+macro SpawnCluster()
+    xba
+    %SetupCoords()
+    %SpawnClusterGeneric()
+endmacro
+
+macro SpawnMinorExtended()
+    xba
+    %SetupCoords()
+    %SpawnMinorExtendedGeneric()
+endmacro
+
+macro SpawnSpinningCoin()
+    xba
+    %SetupCoords()
+    %SpawnSpinningCoinGeneric()
+endmacro
+
+macro SpawnScore()
+    xba
+    %SetupCoords()
+    %SpawnScoreGeneric()
+endmacro

--- a/misc_sprites/score/_header.asm
+++ b/misc_sprites/score/_header.asm
@@ -1,53 +1,58 @@
 @include
 
-macro LDE()
-	LDA !shoot_num,x
-	AND #$40
+macro UpdateYPos()
+    clc 
+    %ScoreUpdateYPos()
+endmacro
+
+macro UpdateYPosAlt()
+    sec 
+    %ScoreUpdateYPos()
 endmacro
 
 macro SetupCoords()
-    lda !shooter_x_low,x
+    lda !score_x_low,x
     sta $04
-    lda !shooter_x_high,x
+    lda !score_x_high,x
     sta $05
-    lda !shooter_y_low,x
+    lda !score_y_low,x
     sta $06
-    lda !shooter_y_high,x
+    lda !score_y_high,x
     sta $07
 endmacro
 
 macro SpawnExtendedAlt()
     xba
     %SetupCoords()
-	%SpawnExtendedGeneric()
+    %SpawnExtendedGeneric()
 endmacro
 
 macro SpawnSmokeAlt()
     xba
     %SetupCoords()
-	%SpawnSmokeGeneric()
+    %SpawnSmokeGeneric()
 endmacro
 
 macro SpawnCluster()
     xba
     %SetupCoords()
-	%SpawnClusterGeneric()
+    %SpawnClusterGeneric()
 endmacro
 
 macro SpawnMinorExtended()
     xba
     %SetupCoords()
-	%SpawnMinorExtendedGeneric()
+    %SpawnMinorExtendedGeneric()
 endmacro
 
 macro SpawnSpinningCoin()
     xba
     %SetupCoords()
-	%SpawnSpinningCoinGeneric()
+    %SpawnSpinningCoinGeneric()
 endmacro
 
 macro SpawnScore()
     xba
     %SetupCoords()
-	%SpawnScoreGeneric()
+    %SpawnScoreGeneric()
 endmacro

--- a/misc_sprites/smoke/_header.asm
+++ b/misc_sprites/smoke/_header.asm
@@ -1,53 +1,48 @@
 @include
 
-macro LDE()
-	LDA !shoot_num,x
-	AND #$40
-endmacro
-
 macro SetupCoords()
-    lda !shooter_x_low,x
+    lda !smoke_x_low,x
     sta $04
-    lda !shooter_x_high,x
+    lda !smoke_x_high,x
     sta $05
-    lda !shooter_y_low,x
+    lda !smoke_y_low,x
     sta $06
-    lda !shooter_y_high,x
+    lda !smoke_y_high,x
     sta $07
 endmacro
 
 macro SpawnExtendedAlt()
     xba
     %SetupCoords()
-	%SpawnExtendedGeneric()
+    %SpawnExtendedGeneric()
 endmacro
 
 macro SpawnSmokeAlt()
     xba
     %SetupCoords()
-	%SpawnSmokeGeneric()
+    %SpawnSmokeGeneric()
 endmacro
 
 macro SpawnCluster()
     xba
     %SetupCoords()
-	%SpawnClusterGeneric()
+    %SpawnClusterGeneric()
 endmacro
 
 macro SpawnMinorExtended()
     xba
     %SetupCoords()
-	%SpawnMinorExtendedGeneric()
+    %SpawnMinorExtendedGeneric()
 endmacro
 
 macro SpawnSpinningCoin()
     xba
     %SetupCoords()
-	%SpawnSpinningCoinGeneric()
+    %SpawnSpinningCoinGeneric()
 endmacro
 
 macro SpawnScore()
     xba
     %SetupCoords()
-	%SpawnScoreGeneric()
+    %SpawnScoreGeneric()
 endmacro

--- a/misc_sprites/spinningcoin/_header.asm
+++ b/misc_sprites/spinningcoin/_header.asm
@@ -1,53 +1,52 @@
 @include
 
-macro LDE()
-	LDA !shoot_num,x
-	AND #$40
+macro UpdateYPos()
+    %SpinningCoinUpdateYPos()
 endmacro
 
 macro SetupCoords()
-    lda !shooter_x_low,x
+    lda !spinning_coin_x_low,x
     sta $04
-    lda !shooter_x_high,x
+    lda !spinning_coin_x_high,x
     sta $05
-    lda !shooter_y_low,x
+    lda !spinning_coin_y_low,x
     sta $06
-    lda !shooter_y_high,x
+    lda !spinning_coin_y_high,x
     sta $07
 endmacro
 
 macro SpawnExtendedAlt()
     xba
     %SetupCoords()
-	%SpawnExtendedGeneric()
+    %SpawnExtendedGeneric()
 endmacro
 
 macro SpawnSmokeAlt()
     xba
     %SetupCoords()
-	%SpawnSmokeGeneric()
+    %SpawnSmokeGeneric()
 endmacro
 
 macro SpawnCluster()
     xba
     %SetupCoords()
-	%SpawnClusterGeneric()
+    %SpawnClusterGeneric()
 endmacro
 
 macro SpawnMinorExtended()
     xba
     %SetupCoords()
-	%SpawnMinorExtendedGeneric()
+    %SpawnMinorExtendedGeneric()
 endmacro
 
 macro SpawnSpinningCoin()
     xba
     %SetupCoords()
-	%SpawnSpinningCoinGeneric()
+    %SpawnSpinningCoinGeneric()
 endmacro
 
 macro SpawnScore()
     xba
     %SetupCoords()
-	%SpawnScoreGeneric()
+    %SpawnScoreGeneric()
 endmacro

--- a/routines/BounceChangeMap16.asm
+++ b/routines/BounceChangeMap16.asm
@@ -1,0 +1,36 @@
+; Routine that changes the map16 tile of a block from inside of a bounce sprite.
+; You'd be better using %InvisibleMap16() and %RevertMap16() instead of this routine.
+;
+; Input: 
+;   A = Map16 to change into ($9C)
+;
+; Output:
+;   N/A
+
+?main:
+    sta $9C
+    lda !bounce_y_low,x
+    clc
+    adc #$08
+    and #$F0
+    sta $98
+    lda !bounce_y_high,x
+    adc #$00
+    sta $99
+    lda !bounce_x_low,x
+    clc
+    adc #$08
+    and #$F0
+    sta $9A
+    lda !bounce_x_high,x
+    adc #$00
+    sta $9B
+    lda !bounce_properties,x
+    asl
+    rol
+    and #$01
+    sta $1933|!addr
+    phx
+    jsl $00BEB0|!BankB
+    plx
+    rtl

--- a/routines/BounceGenericDraw.asm
+++ b/routines/BounceGenericDraw.asm
@@ -1,0 +1,31 @@
+; Draws a single 16x16 tile for a bounce sprite, it also handles the offscreen behavior (X pos high bit)
+; 
+; Input:
+;   A = Tile number to use
+; 
+; Output:
+;   N/A
+
+?main:
+    sta $02
+    %BounceGetDrawInfo()
+    bcc ?.skip
+    
+    lda $00
+    sta $0200|!addr,y
+    lda $01
+    sta $0201|!addr,y
+    lda $02
+    sta $0202|!addr,y
+    lda !bounce_properties,x
+    ora $64
+    sta $0203|!addr,y
+
+    tya 
+    lsr #2
+    tay
+    lda $03
+    sta $0420|!addr,y
+
+?.skip
+    rtl

--- a/routines/BounceGetDrawInfo.asm
+++ b/routines/BounceGetDrawInfo.asm
@@ -1,0 +1,47 @@
+; Routine for bounce sprites that fetches information to draw a it on screen.
+; It handles the offscreen bit and layer 2 offsets.
+; 
+; Input:
+;   N/A
+; 
+; Output: 
+;   $00 = X position within the screen
+;   $01 = Y position within the screen
+;	$03 = OAM size and offscreen bit
+;   Y   = OAM Index
+;   C   = Draw status
+;       Set     = Ready to be drawn on screen
+;       Clear   = Not possible to draw on screen
+
+?main:
+    lda #$02
+    sta $03
+	ldy #$00
+	lda !bounce_properties,x
+	bpl ?.layer_1
+?.layer_2
+	ldy #$04
+?.layer_1
+	lda !bounce_x_low,x
+	sec 
+	sbc.w $1A,y
+	sta $00
+	lda !bounce_x_high,x
+	sbc.w $1B,y
+	beq ?.on_screen_x
+	inc $03
+?.on_screen_x
+	lda !bounce_y_low,x
+	sec 
+	sbc.w $1C,y
+	sta $01
+	lda !bounce_y_high,x
+	sbc.w $1D,y
+	beq ?.on_screen_y
+	clc
+	rtl 
+?.on_screen_y
+    lda.l $0291ED|!BankB,x
+    tay
+	sec
+	rtl

--- a/routines/BounceSetMarioSpeed.asm
+++ b/routines/BounceSetMarioSpeed.asm
@@ -1,0 +1,30 @@
+; Updates the player's speed based on the direction of the bounce sprite.
+;
+; Input:
+;   N/A
+; 
+; Output:
+;   N/A
+
+?main:
+    txy
+    lda !bounce_table,y
+    and #$03
+    tax 
+    lda.l ?.mario_y_speed,x
+    cmp #$80
+    beq ?.no_mario_y_speed
+    sta $7D
+?.no_mario_y_speed
+    lda.l ?.mario_x_speed,x
+    cmp #$80
+    beq ?.no_mario_x_speed
+    sta $7B
+?.no_mario_x_speed
+    tyx 
+	rtl
+
+?.mario_x_speed
+	db $80,$E0,$20,$80
+?.mario_y_speed
+	db $80,$80,$80,$00

--- a/routines/BounceSetSpeed.asm
+++ b/routines/BounceSetSpeed.asm
@@ -1,0 +1,28 @@
+; Routine that updates the speeds of a bounce sprite like the original bounce sprites.
+; 
+; Input:
+;   N/A
+;
+; Output:
+;   N/A
+
+?main:
+    txy
+    lda !bounce_table,y
+    and #$03
+    tax 
+    lda !bounce_y_speed,y
+    clc 
+    adc.l ?.bounce_y_accel,x
+    sta !bounce_y_speed,y
+    lda !bounce_x_speed,y
+    clc 
+    adc.l ?.bounce_x_accel,x
+    sta !bounce_x_speed,y
+    tyx
+    rtl 
+
+?.bounce_x_accel
+	db $00,$F0,$10,$00
+?.bounce_y_accel
+	db $10,$00,$00,$F0

--- a/routines/BounceUpdatePos.asm
+++ b/routines/BounceUpdatePos.asm
@@ -1,0 +1,51 @@
+; Updates the X and Y positions of a bounce sprite based on its speed values
+;
+; Input:
+;   N/A
+; 
+; Output:
+;   N/A
+
+?main:
+    lda !bounce_y_speed,x
+    asl #4
+    clc
+    adc !bounce_y_bits,x
+    sta !bounce_y_bits,x
+    php
+    lda !bounce_y_speed,x
+    lsr #4
+    cmp #$08
+    ldy #$00
+    bcc ?+
+    ora #$F0
+    dey
+?+
+    plp
+    adc !bounce_y_low,x
+    sta !bounce_y_low,x
+    tya
+    adc !bounce_y_high,x
+    sta !bounce_y_high,x
+
+    lda !bounce_x_speed,x
+    asl #4
+    clc
+    adc !bounce_x_bits,x
+    sta !bounce_x_bits,x
+    php
+    lda !bounce_x_speed,x
+    lsr #4
+    cmp #$08
+    ldy #$00
+    bcc ?+
+    ora #$F0
+    dey
+?+
+    plp
+    adc !bounce_x_low,x
+    sta !bounce_x_low,x
+    tya
+    adc !bounce_x_high,x
+    sta !bounce_x_high,x
+    rtl 

--- a/routines/MinorExtendedGetDrawInfo.asm
+++ b/routines/MinorExtendedGetDrawInfo.asm
@@ -1,0 +1,53 @@
+; Routine for minor extended sprites that fetches information to draw a single oam tile on screen.
+; It handles offscreen situations, including X position's high bit.
+; If a minor extended sprite is way too offscreen, the sprite will be erased from memory.
+;
+; Input:
+;   N/A
+; 
+; Output:
+;   $00 = X position within the screen
+;   $01 = Y position within the screen
+;   $02 = X position's high bit
+;   Y   = OAM index
+;   C   = Draw status
+;       Set     = Ready to be drawn on screen
+;       Clear   = Not possible to draw on screen
+
+?main:
+?.check_y
+    lda !minor_extended_y_low,x
+    sec 
+    sbc $1C 
+    sta $01
+    cmp #$E0
+    bcc ?.check_x
+    clc 
+    adc #$10
+    bpl ?.check_x
+?.kill
+    stz !minor_extended_num,x
+?.invalid
+    clc 
+    rtl
+
+?.check_x
+    stz $02
+    lda !minor_extended_x_low,x
+    sec 
+    sbc $1A
+    sta $00
+    lda !minor_extended_x_high,x
+    sbc $1B
+    beq ?.on_screen_x
+    lda $00
+    clc 
+    adc #$38            ; range for despawn
+    cmp #$70
+    bcs ?.kill
+    inc $02
+?.on_screen_x
+    lda.l $028B77|!BankB,x
+    tay
+    sec 
+    rtl

--- a/routines/MinorExtendedSpeed.asm
+++ b/routines/MinorExtendedSpeed.asm
@@ -1,0 +1,96 @@
+; Updates the minor extended sprite's position based on its speed
+; Depending on A, it will have behave differently
+;   A = Update type
+;       00 = Slow, X position
+;       01 = Fast, X position
+;       02 = Slow, Y position
+;       03 = Fast, Y position
+; The slow version is accurater as it uses fractional speed values, but has higher cycle usage.
+;   0x01 unit = 1/16th of a pixel
+;   0x10 units = 1 pixel
+; The fast version is less accurate as it doesn't use fractional speed values, but it has lower cycle usage.
+;   0x01 unit = 0x01 pixel
+;   0x10 units = 0x10 pixels
+
+?main:
+    lsr
+    bcc ?.slow
+
+; use faster, inaccurate, method of updating position
+
+?.fast
+    lsr 
+    bcs ?..y
+?..x
+    ldy #$00
+    lda !minor_extended_x_speed,x
+    bpl $01
+    dey 
+    clc 
+    adc !minor_extended_x_low,x
+    sta !minor_extended_x_low,x
+    tya 
+    adc !minor_extended_x_high,x
+    sta !minor_extended_x_high,x
+    rtl
+    
+?..y
+    ldy #$00
+    lda !minor_extended_y_speed,x
+    bpl $01
+    dey 
+    clc 
+    adc !minor_extended_y_low,x
+    sta !minor_extended_y_low,x
+    tya 
+    adc !minor_extended_y_high,x
+    sta !minor_extended_y_high,x
+    rtl
+
+; slower but accurater method of updating position
+
+?.slow
+    lsr 
+    bcs ?..y
+?..x
+    lda !minor_extended_x_speed,x
+    asl #4
+    clc 
+    adc !minor_extended_x_fraction,x
+    sta !minor_extended_x_fraction,x
+    php
+    ldy #$00
+    lda !minor_extended_x_speed,x
+    lsr #4
+    cmp #$08
+    bcc $03
+    ora #$F0
+    dey
+    plp 
+    adc !minor_extended_x_low,x
+    sta !minor_extended_x_low,x
+    tya 
+    adc !minor_extended_x_high,x
+    sta !minor_extended_x_high,x
+    rtl
+?..y
+    lda !minor_extended_y_speed,x
+    asl #4
+    clc 
+    adc !minor_extended_y_fraction,x
+    sta !minor_extended_y_fraction,x
+    php
+    ldy #$00
+    lda !minor_extended_y_speed,x
+    lsr #4
+    cmp #$08
+    bcc $03
+    ora #$F0
+    dey
+    plp 
+    adc !minor_extended_y_low,x
+    sta !minor_extended_y_low,x
+    tya 
+    adc !minor_extended_y_high,x
+    sta !minor_extended_y_high,x
+    rtl

--- a/routines/ScoreGenericDraw.asm
+++ b/routines/ScoreGenericDraw.asm
@@ -1,0 +1,45 @@
+; Generic routine to draw a score sprite with two 8x8 tiles
+; and priority over every layer, similar to SMW's score sprites.
+; 
+; Input:
+;   $07 = Left tile number
+;   $08 = Right tile number
+;   $09 = Left tile properties
+;   $0A = Right tile properties
+; 
+; Output: 
+;   C   = Draw status
+;       Set     = Score sprite drawn on screen
+;       Clear   = Score sprite not drawn on screen
+
+
+?main:
+    %ScoreGetDrawInfo()
+    bcc ?.return
+    lda $00
+    sta $0200|!addr,y
+    clc 
+    adc #$08
+    sta $0204|!addr,y 
+    lda $01
+    sta $0201|!addr,y
+    sta $0205|!addr,y
+    lda $07
+    sta $0202|!addr,y
+    lda $08
+    sta $0206|!addr,y
+    lda $09
+    ora #$30
+    sta $0203|!addr,y
+    lda $0A
+    ora #$30
+    sta $0207|!addr,y
+    tya 
+    lsr #2
+    tay 
+    lda #$00
+    sta $0420|!addr,y
+    sta $0421|!addr,y
+    sec 
+?.return
+    rtl

--- a/routines/ScoreGetDrawInfo.asm
+++ b/routines/ScoreGetDrawInfo.asm
@@ -1,0 +1,64 @@
+; Routine for score sprites that fetches information to draw a it on screen.
+; 
+; Input:
+;   N/A
+; 
+; Output: 
+;   $00 = X position within the screen
+;   $01 = Y position within the screen
+;   Y   = OAM Index
+;   C   = Draw status
+;       Set     = Ready to be drawn on screen
+;       Clear   = Not possible to draw on screen
+
+?main:
+    lda !score_layer,x
+    asl #2
+    tay 
+    rep #$20
+    lda.w $1C|!dp,y
+    sta $02
+    lda.w $1A|!dp,y
+    sta $04
+    sep #$20
+
+    lda !score_x_low,x
+    clc 
+    adc #$0C
+    php 
+    sec 
+    sbc $04
+    lda !score_x_high,x
+    sbc $05
+    plp 
+    adc #$00
+    bne ?.return
+    lda !score_x_low,x
+    cmp $04
+    lda !score_x_high,x
+    sbc $05
+    bne ?.return
+
+    lda !score_y_low,x
+    cmp $02
+    lda !score_y_high,x
+    sbc $03
+    bne ?.return
+
+?.valid
+    lda !score_x_low,x
+    sec 
+    sbc $04
+    sta $00
+    lda !score_y_low,x
+    sec 
+    sbc $02
+    sta $01
+    lda.l $02AD9E|!BankB,x
+    tay 
+    sec 
+    rtl 
+
+?.return
+    clc 
+    rtl

--- a/routines/ScoreUpdateYPos.asm
+++ b/routines/ScoreUpdateYPos.asm
@@ -1,0 +1,42 @@
+; Routine that updates score's sprites Y position based on its speed.
+; It also handles how high the score sprite can go.
+; You'd be better using %UpdateYPos() for default SMW behavior or
+; %UpdateYPosAlt() for easy handling of the upper limit of the score sprite
+;
+; Input:
+;   C = Use SMW's highest position value
+;   A = If carry set, highest position relative to the camera the score sprite can reach
+; 
+; Output:
+;   N/A
+
+?main:
+    bcs ?.already_set
+    lda #$04
+?.already_set
+    sta $00
+    phb
+    phk
+    plb
+    lda !score_y_speed,x
+    lsr #4
+    tay 
+    lda $13
+    and ?.point_speed_y,y
+    bne ?.return
+    lda !score_y_low,x
+    tay 
+    sec 
+    sbc $1C 
+    cmp $00
+    bcc ?.return
+    dec !score_y_low,x
+    tya 
+    bne ?.return
+    dec !score_y_high,x
+?.return
+    plb
+    rtl
+
+?.point_speed_y 
+    db $03,$01,$00,$00

--- a/routines/SmokeGenericDraw.asm
+++ b/routines/SmokeGenericDraw.asm
@@ -1,0 +1,32 @@
+; Routine that simplifies the process of writing oam tiles for smoke sprites.
+; It will draw a single tile at the smoke's position.
+;
+; Input: 
+;   $02 = Tile number to show
+;   $03 = YXPPCCCT properties of the tile
+;   $04 = Tile size & X high bit
+; 
+; Output:
+;   C   = Draw status
+;       Set     = Smoke sprite drawn on screen
+;       Clear   = Smoke sprite not drawn on screen
+
+?main:
+    %SmokeGetDrawInfo()
+    bcc ?.return
+    lda $00
+    sta $0200|!addr,y
+    lda $01
+    sta $0201|!addr,y
+    lda $02
+    sta $0202|!addr,y
+    lda $03
+    sta $0203|!addr,y
+    tya 
+    lsr #2
+    tay 
+    lda $04
+    sta $0420|!addr,y
+    sec 
+?.return
+    rtl

--- a/routines/SmokeGetDrawInfo.asm
+++ b/routines/SmokeGetDrawInfo.asm
@@ -1,0 +1,33 @@
+; Routine for smoke sprites that fetches information to draw a single oam tile on screen.
+;
+; Input:
+;   N/A
+; 
+; Output:
+;   $00 = X position within the screen
+;   $01 = Y position within the screen
+;   Y   = OAM index
+;   C   = Draw status
+;       Set     = Ready to be drawn on screen
+;       Clear   = Not possible to draw on screen
+
+?main:
+?.check_x
+    lda !smoke_x_low,x
+    sec 
+    sbc $1A
+    cmp #$F0
+    bcs ?.nope
+    sta $00
+?.check_y
+    lda !smoke_y_low,x
+    sec 
+    sbc $1C
+    sta $01
+    lda.l $0296B8|!BankB,x
+    tay
+    sec 
+    rtl
+?.nope
+    clc 
+    rtl 

--- a/routines/SpawnExtendedGeneric.asm
+++ b/routines/SpawnExtendedGeneric.asm
@@ -1,0 +1,65 @@
+; Routine used for spawning extended sprites with initial speed at the position (+offset)
+; of the calling sprite and returns the sprite index in Y
+; For a list of extended sprites see here: 
+; https://www.smwcentral.net/?p=memorymap&a=detail&game=smw&region=ram&detail=d22e80035676
+;
+; Input:
+;   A   = number
+;   $00 = x offset
+;   $01 = y offset
+;   $02 = x speed
+;   $03 = y speed
+;   $04 = origin x pos  ; since this is a generic routine it can be called from any other sprite
+;   $06 = origin y pos  ; type, so i opted for adding macros in _header.asm that helps to setup this
+
+; Output:
+;   Y = index to extended sprite ($FF means no sprite spawned)
+;   C = Spawn status
+;       Set = Spawn failed
+;       Clear = Spawn successful
+
+?main:
+    ldy.b #!ExtendedSize-1
+?.loop
+    lda !extended_num,y
+    beq ?.found
+    dey 
+    bpl ?.loop
+?.ret
+    sec 
+    rtl
+
+?.found
+    xba 
+    sta !extended_num,y
+    
+    lda $00
+    clc 
+    adc $04
+    sta !extended_x_low,y
+    lda #$00
+    bit $00
+    bpl $01
+    dec 
+    adc $05
+    sta !extended_x_high,y
+
+    lda $01
+    clc 
+    adc $06
+    sta !extended_y_low,y
+    lda #$00
+    bit $01
+    bpl $01
+    dec 
+    adc $07
+    sta !extended_y_high,y
+
+    lda $02
+    sta !extended_x_speed,y
+    lda $03
+    sta !extended_y_speed,y
+
+    clc
+    rtl
+

--- a/routines/SpawnMinorExtendedGeneric.asm
+++ b/routines/SpawnMinorExtendedGeneric.asm
@@ -1,0 +1,65 @@
+; Routine used for spawning minor extended sprites with initial speed at the position (+offset)
+; of the calling sprite and returns the sprite index in Y
+; For a list of minor extended sprites see here: 
+; https://www.smwcentral.net/?p=memorymap&a=detail&game=smw&region=ram&detail=11c9baba28dd
+
+; Input:
+;   A   = number
+;   $00 = x offset
+;   $01 = y offset
+;   $02 = x speed
+;   $03 = y speed
+;   $04 = origin x pos  ; since this is a generic routine it can be called from any other sprite
+;   $06 = origin y pos  ; type, so i opted for adding macros in _header.asm that helps to setup this
+
+; Output:
+;   Y = index to minor extended sprite ($FF means no sprite spawned)
+;   C = Spawn status
+;       Set = Spawn failed
+;       Clear = Spawn successful
+
+?main:
+
+    ldy.b #!MinorExtendedSize-1
+?.loop
+    lda !minor_extended_num,y
+    beq ?.found
+    dey 
+    bpl ?.loop
+?.ret
+    sec 
+    rtl
+
+?.found
+    xba 
+    sta !minor_extended_num,y
+    
+    lda $00
+    clc 
+    adc $04
+    sta !minor_extended_x_low,y
+    lda #$00
+    bit $00
+    bpl $01
+    dec 
+    adc $05
+    sta !minor_extended_x_high,y
+
+    lda $01
+    clc 
+    adc $06
+    sta !minor_extended_y_low,y
+    lda #$00
+    bit $01
+    bpl $01
+    dec 
+    adc $07
+    sta !minor_extended_y_high,y
+
+    lda $02
+    sta !minor_extended_x_speed,y
+    lda $03
+    sta !minor_extended_y_speed,y
+    
+    clc 
+    rtl

--- a/routines/SpawnScoreGeneric.asm
+++ b/routines/SpawnScoreGeneric.asm
@@ -1,0 +1,60 @@
+; Routine used for spawning score sprites with initial speed at the position (+offset)
+; of the calling sprite and returns the sprite index in Y
+; For a list of score sprites see here: 
+; https://www.smwcentral.net/?p=memorymap&a=detail&game=smw&region=ram&detail=befc37dd6e48
+;
+; Input:
+;   A   = number
+;   $00 = x offset
+;   $01 = y offset
+;   $04 = origin x pos  ; since this is a generic routine it can be called from any other sprite
+;   $06 = origin y pos  ; type, so i opted for adding macros in _header.asm that helps to setup this
+
+; Output:
+;   Y = index to score sprite
+
+?main:
+    ldy.b #!ScoreSize-1
+?.loop
+    lda !score_num,y
+    beq ?.found
+    dey 
+    bpl ?.loop
+    dec $18F7|!addr
+    bpl ?.force
+    lda.b #!ScoreSize-1
+    sta $18F7|!addr
+?.force
+    ldy $18F7|!addr
+
+?.found
+    xba 
+    sta !score_num,y
+    
+    lda $00
+    clc 
+    adc $04
+    sta !score_x_low,y
+    lda #$00
+    bit $00
+    bpl $01
+    dec 
+    adc $05
+    sta !score_x_high,y
+
+    lda $01
+    clc 
+    adc $06
+    sta !score_y_low,y
+    lda #$00
+    bit $01
+    bpl $01
+    dec 
+    adc $07
+    sta !score_y_high,y
+
+    lda #$30
+    sta !score_y_speed,y
+
+    rtl
+

--- a/routines/SpawnSmokeGeneric.asm
+++ b/routines/SpawnSmokeGeneric.asm
@@ -1,0 +1,51 @@
+; Routine used for spawning smoke sprites with initial speed at the position (+offset)
+; of the calling sprite and returns the sprite index in Y
+; For a list of smoke sprites see here: 
+; https://www.smwcentral.net/?p=memorymap&a=detail&game=smw&region=ram&detail=884f711d6fb3
+;
+; Input:
+;   A   = number
+;   $00 = x offset
+;   $01 = y offset
+;	$02 = timer
+;   $04 = origin x pos  ; since this is a generic routine it can be called from any other sprite
+;   $06 = origin y pos  ; type, so i opted for adding macros in _header.asm that helps to setup this
+
+; Output:
+;   Y = index to smoke sprite ($FF means no sprite spawned)
+;   C = Spawn status
+;       Set = Spawn failed
+;       Clear = Spawn successful
+
+?main:
+    ldy.b #!SmokeSize-1
+?.loop
+    lda !smoke_num,y
+    beq ?.found
+    dey 
+    bpl ?.loop
+?.ret
+    sec 
+    rtl
+
+?.found
+    xba 
+    sta !smoke_num,y
+    
+    lda $00
+    clc 
+    adc $04
+    sta !smoke_x_low,y
+
+    lda $01
+    clc 
+    adc $06
+    sta !smoke_y_low,y
+
+    lda $02
+    sta !smoke_timer,y
+
+    clc
+    rtl
+
+

--- a/routines/SpawnSpinningCoinGeneric.asm
+++ b/routines/SpawnSpinningCoinGeneric.asm
@@ -1,0 +1,60 @@
+; Routine used for spawning spinning coin sprites with initial speed at the position (+offset)
+; of the calling sprite and returns the sprite index in Y
+;
+; Input:
+;   A   = number
+;   $00 = x offset
+;   $01 = y offset
+;   $03 = y speed
+;   $04 = origin x pos  ; since this is a generic routine it can be called from any other sprite
+;   $06 = origin y pos  ; type, so i opted for adding macros in _header.asm that helps to setup this
+
+; Output:
+;   Y = index to spinning coin sprite ($FF means no sprite spawned)
+;   C = Spawn status
+;       Set = Spawn failed
+;       Clear = Spawn successful
+
+?main:
+    ldy.b #!SpinningCoinSize-1
+?.loop
+    lda !spinning_coin_num,y
+    beq ?.found
+    dey 
+    bpl ?.loop
+?.ret
+    sec 
+    rtl
+
+?.found
+    xba 
+    sta !spinning_coin_num,y
+    
+    lda $00
+    clc 
+    adc $04
+    sta !spinning_coin_x_low,y
+    lda #$00
+    bit $00
+    bpl $01
+    dec 
+    adc $05
+    sta !spinning_coin_x_high,y
+
+    lda $01
+    clc 
+    adc $06
+    sta !spinning_coin_y_low,y
+    lda #$00
+    bit $01
+    bpl $01
+    dec 
+    adc $07
+    sta !spinning_coin_y_high,y
+
+    lda $03
+    sta !spinning_coin_y_speed,y
+
+    clc
+    rtl
+    

--- a/routines/SpinningCoinGetDrawInfo.asm
+++ b/routines/SpinningCoinGetDrawInfo.asm
@@ -1,0 +1,48 @@
+; Routine for bounce sprites that fetches information to draw a it on screen.
+; It handles the offscreen bit and layer 2 offsets.
+; 
+; Input:
+;   N/A
+; 
+; Output: 
+;   $00 = X position within the screen
+;   $01 = Y position within the screen
+;	$03 = OAM size and offscreen bit
+;   Y   = OAM Index
+;   C   = Draw status
+;       Set     = Ready to be drawn on screen
+;       Clear   = Not possible to draw on screen
+
+?main:
+    lda !spinning_coin_layer,x
+    asl #2
+    tay
+    rep #$20
+    lda.w $1C|!dp,y
+    sta $02
+    lda.w $1A|!dp,y
+    sta $04
+    sep #$20
+    lda !spinning_coin_y_low,x
+    cmp $02
+    lda !spinning_coin_y_high,x
+    sbc $04
+    bne ?.return
+    lda !spinning_coin_x_low,x
+    sbc $03
+    cmp #$F8
+    bcs ?.kill
+    sta $00
+    lda !spinning_coin_y_low,x
+    sec 
+    sbc $02
+    sta $01
+    lda.l $0299E9|!BankB,x
+    tay
+    sec 
+    rtl
+?.kill
+    stz !spinning_coin_num,x
+?.return
+    clc 
+    rtl 

--- a/routines/SpinningCoinUpdateYPos.asm
+++ b/routines/SpinningCoinUpdateYPos.asm
@@ -1,0 +1,31 @@
+; Routine to update the Y position of a spinning coin sprite.
+; 
+; Input:
+;   N/A
+; 
+; Output:
+;   N/A
+
+
+?main:
+    LDA !spinning_coin_y_speed,x
+    ASL #4
+    CLC 
+    ADC !spinning_coin_y_bits,x
+    STA !spinning_coin_y_bits,x
+    PHP 
+    LDY #$00
+    LDA !spinning_coin_y_speed,x
+    LSR #4
+    CMP #$08
+    BCC ?.pos
+    ORA #$F0
+    DEY
+?.pos
+    PLP
+    ADC !spinning_coin_y_low,x
+    STA !spinning_coin_y_low,x
+    TYA 
+    ADC !spinning_coin_y_high,x
+    STA !spinning_coin_y_high,x
+    RTL

--- a/sprites/_header.asm
+++ b/sprites/_header.asm
@@ -4,3 +4,43 @@ macro LDE()
 	LDA !extra_bits,x
 	AND #$04
 endmacro
+
+macro SetupCoords()
+    lda !sprite_x_low,x
+    sta $04
+    lda !sprite_x_high,x
+    sta $05
+    lda !sprite_y_low,x
+    sta $06
+    lda !sprite_y_high,x
+    sta $07
+endmacro
+
+macro SpawnMinorExtended()
+    xba
+    lda !sprite_off_screen_horz,x
+    ora !sprite_off_screen_vert,x
+    ora !sprite_being_eaten,x
+    bne ?ret
+    %SetupCoords()
+	%SpawnMinorExtendedGeneric()
+?ret 
+endmacro
+
+macro SpawnCluster()
+    xba
+    %SetupCoords()
+	%SpawnClusterGeneric()
+endmacro
+
+macro SpawnSpinningCoin()
+    xba
+    %SetupCoords()
+	%SpawnSpinningCoinGeneric()
+endmacro
+
+macro SpawnScore()
+    xba
+    %SetupCoords()
+	%SpawnScoreGeneric()
+endmacro

--- a/src/config.h
+++ b/src/config.h
@@ -23,18 +23,7 @@ enum class PathType : int {
 
 enum class ExtType : int { Ssc, Mwt, Mw2, S16, __SIZE__ };
 
-enum class ListType : int {
-    Sprite = 0,
-    Extended = 1,
-    Cluster = 2,
-    MinorExtended = 3,
-    Bounce = 4,
-    Smoke = 5,
-    SpinningCoin = 6,
-    Score = 7,
-    Overworld = 8,
-    __SIZE__ = 9
-};
+enum class ListType : int { Sprite, Extended, Cluster, MinorExtended, Bounce, Smoke, SpinningCoin, Score, __SIZE__ };
 
 template <typename T> constexpr auto FromEnum(T val) {
     return static_cast<std::underlying_type_t<T>>(val);

--- a/src/config.h
+++ b/src/config.h
@@ -13,18 +13,32 @@ enum class PathType : int {
     Extended,
     Cluster,
     MinorExtended,
+    Bounce,
+    Smoke,
+    SpinningCoin,
+    Score,
     // Overworld,
-    SIZE // this is here as a shorthand for counting how many elements are in the enum
+    __SIZE__ // this is here as a shorthand for counting how many elements are in the enum
 };
 
-enum class ExtType : int { Ssc, Mwt, Mw2, S16, SIZE };
+enum class ExtType : int { Ssc, Mwt, Mw2, S16, __SIZE__ };
 
-enum class ListType : int { Sprite = 0, Extended = 1, Cluster = 2, MinorExtended = 3, Overworld = 4 };
+enum class ListType : int {
+    Sprite = 0,
+    Extended = 1,
+    Cluster = 2,
+    MinorExtended = 3,
+    Bounce = 4,
+    Smoke = 5,
+    SpinningCoin = 6,
+    Score = 7,
+    Overworld = 8,
+    __SIZE__ = 9
+};
 
 template <typename T> constexpr auto FromEnum(T val) {
     return static_cast<std::underlying_type_t<T>>(val);
 }
-
 
 struct Debug {
     bool isOn = false;
@@ -43,7 +57,7 @@ struct Debug {
 };
 
 struct Paths {
-    static constexpr int ArrSize = FromEnum(PathType::SIZE);
+    static constexpr int ArrSize = FromEnum(PathType::__SIZE__);
     std::string list{"list.txt"};
     std::string pasm{"asm/"};
     std::string sprites{"sprites/"};
@@ -51,26 +65,32 @@ struct Paths {
     std::string generators{"generators/"};
     std::string extended{"extended/"};
     std::string cluster{"cluster/"};
-    std::string minorextended{ "minorextended/" };
+    std::string minorextended{"misc_sprites/minorextended/"};
+    std::string bounce{"misc_sprites/bounce/"};
+    std::string smoke{"misc_sprites/smoke/"};
+    std::string spinningcoin{"misc_sprites/spinningcoin/"};
+    std::string score{"misc_sprites/score/"};
     std::string routines{"routines/"};
 
     inline constexpr std::string &operator[](int index) noexcept {
-        std::array<std::string *, ArrSize> paths{&routines, &sprites, &generators, &shooters,
-                                                 &list,     &pasm,    &extended,   &cluster, &minorextended};
+        std::array<std::string *, ArrSize> paths{&routines, &sprites,      &generators, &shooters,      &list,
+                                                 &pasm,     &extended,     &cluster,    &minorextended, &bounce,
+                                                 &smoke,    &spinningcoin, &score};
         index = std::clamp(index, 0, (int)paths.size() - 1);
         return *paths[index];
     };
 
     inline constexpr const std::string &operator[](int index) const noexcept {
-        std::array<const std::string *, ArrSize> paths{&routines, &sprites, &generators, &shooters,
-                                                       &list,     &pasm,    &extended,   &cluster, &minorextended};
+        std::array<const std::string *, ArrSize> paths{&routines, &sprites,      &generators, &shooters,      &list,
+                                                       &pasm,     &extended,     &cluster,    &minorextended, &bounce,
+                                                       &smoke,    &spinningcoin, &score};
         index = std::clamp(index, 0, (int)paths.size() - 1);
         return *paths[index];
     };
 };
 
 struct Extensions {
-    static constexpr int ArrSize = FromEnum(ExtType::SIZE);
+    static constexpr int ArrSize = FromEnum(ExtType::__SIZE__);
     std::string ssc{};
     std::string mwt{};
     std::string mw2{};

--- a/src/config.h
+++ b/src/config.h
@@ -12,13 +12,14 @@ enum class PathType : int {
     Asm,
     Extended,
     Cluster,
+    MinorExtended,
     // Overworld,
     SIZE // this is here as a shorthand for counting how many elements are in the enum
 };
 
 enum class ExtType : int { Ssc, Mwt, Mw2, S16, SIZE };
 
-enum class ListType : int { Sprite = 0, Extended = 1, Cluster = 2, Overworld = 3 };
+enum class ListType : int { Sprite = 0, Extended = 1, Cluster = 2, MinorExtended = 3, Overworld = 4 };
 
 template <typename T> constexpr auto FromEnum(T val) {
     return static_cast<std::underlying_type_t<T>>(val);
@@ -50,18 +51,19 @@ struct Paths {
     std::string generators{"generators/"};
     std::string extended{"extended/"};
     std::string cluster{"cluster/"};
+    std::string minorextended{ "minorextended/" };
     std::string routines{"routines/"};
 
     inline constexpr std::string &operator[](int index) noexcept {
         std::array<std::string *, ArrSize> paths{&routines, &sprites, &generators, &shooters,
-                                                 &list,     &pasm,    &extended,   &cluster};
+                                                 &list,     &pasm,    &extended,   &cluster, &minorextended};
         index = std::clamp(index, 0, (int)paths.size() - 1);
         return *paths[index];
     };
 
     inline constexpr const std::string &operator[](int index) const noexcept {
         std::array<const std::string *, ArrSize> paths{&routines, &sprites, &generators, &shooters,
-                                                       &list,     &pasm,    &extended,   &cluster};
+                                                       &list,     &pasm,    &extended,   &cluster, &minorextended};
         index = std::clamp(index, 0, (int)paths.size() - 1);
         return *paths[index];
     };

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -473,7 +473,7 @@ void clean_hack(ROM &rom, std::string_view pathname) {
             clean_sprite_generic(clean_patch, 0x029B1F, 0x176FBC, SPRITE_COUNT, "\n\n;Extended:\n", rom);
             clean_sprite_generic(clean_patch, 0x028B70, 0x942016, LESS_SPRITE_COUNT, "\n\n;MinorExtended:\n", rom);
             clean_sprite_generic(clean_patch, 0x029058, 0x03F016, LESS_SPRITE_COUNT, "\n\n;Bounce:\n", rom);
-            clean_sprite_generic(clean_patch, 0x0296C0, 0x17C0BD, LESS_SPRITE_COUNT, "\n\n;Smoke:\n", rom);
+            clean_sprite_generic(clean_patch, 0x0296C4, 0x7F2912, LESS_SPRITE_COUNT, "\n\n;Smoke:\n", rom);
             clean_sprite_generic(clean_patch, 0x0299DA, 0x2003F0, MINOR_SPRITE_COUNT, "\n\n;SpinningCoin:\n", rom);
             clean_sprite_generic(clean_patch, 0x02ADBE, 0xF016E1, MINOR_SPRITE_COUNT, "\n\n;Score:\n", rom);
         }


### PR DESCRIPTION
ASM Side authored by @TheLx5

This patch adds support for:
- Minor extended sprites
- Smoke sprites
- Bounce sprites
- Spinning coin sprites
- Score sprites