### PR TITLE
Switch back to relative filenames.

### DIFF
--- a/src/paths.cpp
+++ b/src/paths.cpp
@@ -14,12 +14,12 @@ std::string cleanPathTrail(std::string path) {
     return path;
 }
 
-void set_paths_relative_to(std::string& path, const char *arg0) {
+void set_paths_relative_to(std::string &path, const char *arg0) {
 
     if (path.empty())
         return;
 
-    std::filesystem::path absBasePath(std::filesystem::absolute(arg0));
+    std::filesystem::path absBasePath = std::filesystem::relative(arg0);
     absBasePath.remove_filename();
 #ifdef DEBUGMSG
     debug_print("Absolute base path: %s ", absBasePath.generic_string().c_str());

--- a/src/paths.h
+++ b/src/paths.h
@@ -11,7 +11,7 @@ template <typename... A> void debug_print(const char *msg, A... args) {
 bool nameEndWithAsmExtension(const char *name);
 bool nameEndWithAsmExtension(std::string_view name);
 std::string cleanPathTrail(std::string path);
-void set_paths_relative_to(std::string& path, const char *arg0);
+void set_paths_relative_to(std::string &path, const char *arg0);
 // combines the path of src and file
 // if src is a file itself, it will backtrace to the containing directory
 // if src is a direcotry, it needs to have a trailing /

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -98,7 +98,7 @@ template <typename T> T *from_table(T *table, int level, int number) {
 }
 
 bool patch(const char *patch_name_rel, ROM &rom) {
-    std::string patch_path = std::filesystem::absolute(patch_name_rel).generic_string();
+    std::string patch_path{patch_name_rel}; //  = std::filesystem::absolute(patch_name_rel).generic_string();
     if (!asar_patch(patch_path.c_str(), (char *)rom.real_data, MAX_ROM_SIZE, &rom.size)) {
 #ifdef DEBUGMSG
         debug_print("Failure. Try fetch errors:\n");
@@ -1088,7 +1088,7 @@ int main(int argc, char *argv[]) {
         else
             set_paths_relative_to(cfg.m_Paths[i], argv[0]);
 #ifdef DEBUGMSG
-        debug_print("paths[%d] = %s\n", i, paths[i]);
+        debug_print("paths[%d] = %s\n", i, cfg.m_Paths[i].c_str());
 #endif
     }
     cfg.AsmDir = cfg.m_Paths[FromEnum(PathType::Asm)];
@@ -1097,7 +1097,7 @@ int main(int argc, char *argv[]) {
     for (int i = 0; i < FromEnum(ExtType::__SIZE__); i++) {
         set_paths_relative_to(cfg.m_Extensions[i], rom.name);
 #ifdef DEBUGMSG
-        debug_print("extensions[%d] = %s\n", i, extensions[i]);
+        debug_print("extensions[%d] = %s\n", i, cfg.m_Extensions[i].c_str());
 #endif
     }
 


### PR DESCRIPTION
This is a revert on the relative <-> absolute filename change that I made some time ago. 
It should at least somewhat contain the damage that #39 could cause (due to shorter paths, not an actual fix)
Currently barely tested, not tested at all with weird configurations.