### PR TITLE
ExtendedGetDrawInfo: properly despawn when extended sprite is vertically offscreen

### DIFF
--- a/routines/ExtendedGetDrawInfo.asm
+++ b/routines/ExtendedGetDrawInfo.asm
@@ -23,13 +23,15 @@
     SBC $1C
     STA $02
     LDA !extended_y_high,x
-    ADC $1D
-    BEQ ?.neg
+    SBC $1D
+    BNE ?.vert_offscreen
     LDA $02
     CMP #$F0
     BCS ?.erasespr
     RTL
-?.neg
+?.vert_offscreen
+    CMP #$FF
+    BNE ?.erasespr ; erase: not within 1 screen above top of screen
     LDA $02
     CMP #$C0
     BCC ?.erasespr


### PR DESCRIPTION
Some example inputs that should despawn the extended sprite, but don't:
Layer 1 Y pos: $05F3; Extended sprite pos: $01C4
$01F3; $00C4
$01F3; $02F4