### PR TITLE
Fix generate_json.py incremental build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if (PIXI_BUILD_TESTS)
 	add_subdirectory(unittests)
 endif()
 add_custom_command(
-	OUTPUT "src/json_const.h" "src/CFG Editor/CFG Editor/Json/JsonConst.cs" 
+	OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/src/json_const.h" "${CMAKE_CURRENT_SOURCE_DIR}/src/CFG Editor/CFG Editor/Json/JsonConst.cs"
 	COMMAND ${Python_EXECUTABLE} generate_json.py
 	DEPENDS tweak_bit_names.json generate_json.py
 	COMMENT "Generating JSON tweak source files"


### PR DESCRIPTION
generate_json.py generates files in pixi/src, but CMake expects files to be under the build directory by default.

This fixes this warning:
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Msbuild\Microsoft\VC\v160\Microsoft.CppCommon.targets(241,5): warning MSB8065: Custom build for item "C:\SpriteToolSuperDelux\build\CMakeFiles\2afc6afa099181c1627c0ee8e456171a\json_const.h.rule" succeeded, but specified output "c:\spritetoolsuperdelux\build\src\json_const.h" has not been created. This may cause incremental build to work incorrectly.