### PR TITLE
Small fixes and optimizations

### DIFF
--- a/asm/bounce.asm
+++ b/asm/bounce.asm
@@ -20,7 +20,7 @@ Main:
     BCC .original
 
 .custom
-    SEC 
+    ;SEC 
     SBC.b #!BounceOffset
     AND #$3F
     %CallSprite(Ptr)

--- a/asm/cluster.asm
+++ b/asm/cluster.asm
@@ -19,9 +19,9 @@ NotQuiteMain:
 	STZ $1498|!Base2      ; | 
 	STZ $1495|!Base2      ; /
 	REP #$20
-	LDX #$9E              ; \ Set $1E02-$1EA1 to zero on level load.
+	LDX #$9F              ; \ Set $1E02-$1EA1 to zero on level load.
 .loop                     ; |
-	STZ !cluster_y_low,x  ; |
+	STZ !cluster_y_low-1,x; |
 	DEX                   ; |
 	DEX                   ; |
 	BNE .loop             ; /
@@ -43,8 +43,8 @@ Main:
 
 .custom:
 	;PHB : PHK : PLB       ; magic bank wrapper
-	SEC                   ; \ Subtract 9. (Also allows you to use slots up to $88 instead of $7F in this version.)
-	SBC #$09              ; / (Not that you'll ever use all of them though)
+	;SEC                   ; \ Subtract 9. (Also allows you to use slots up to $88 instead of $7F in this version.)
+	SBC.b #!ClusterOffset ; / (Not that you'll ever use all of them though)
 	AND #$7F
 
 	%CallSprite(Ptr)

--- a/asm/extended.asm
+++ b/asm/extended.asm
@@ -22,7 +22,8 @@ CapeInteract:
 	LDA !extended_num,x		; restore vanilla code
 	CMP #!ExtendedOffset
 	BCC .NotCustom
-	SEC : SBC #!ExtendedOffset
+	;SEC
+	SBC #!ExtendedOffset
 	AND #$7F
 	%CallExtCape(CapePtr)
 	JML $029653|!BankB
@@ -40,7 +41,7 @@ Main:
 	CMP #!ExtendedOffset  ; check if number higher than #$13
 	BCC .NotCustom        ;
 
-	SEC
+	;SEC
    SBC #!ExtendedOffset  ; 13 is the first custom one
 	AND #$7F              ;	
 	%CallSprite(Ptr)      ;

--- a/asm/main.asm
+++ b/asm/main.asm
@@ -804,7 +804,7 @@ SubGenLoad:
     LDA !new_code_flag
     STA $18B9|!Base2
     LDA $05
-    SEC
+    ;SEC
     SBC #!GenStart-1
     ORA $18B9|!Base2
     JML $02A8B8|!BankB
@@ -832,16 +832,16 @@ SubShootLoad:
     SEC
     SBC #$C8
     if !SA1
-        STA $7783,x
+        STA !shoot_num,x
     endif
     JML SubShootLoadReturn
 .IsCustom
-    STA $1783|!Base2,x
+    STA !shoot_num,x
     LDA $04
     SEC
     SBC #$BF
-    ORA $1783|!Base2,x
-    STA $1783|!Base2,x
+    ORA !shoot_num,x
+    STA !shoot_num,x
     PHA
 
     ; A = 000000EE NNNNNNNN (index to size table)
@@ -914,22 +914,22 @@ endif
 
 SubShootExec:
     %debugmsg("SubShootExec")
-    LDY $1783|!Base2,x
+    LDY !shoot_num,x
     BMI .IsCustom
-    LDY $17AB|!Base2,x
+    LDY !shoot_timer,x
     BEQ .Loc2
     JML $02B39A|!BankB
 .Loc2
     JML $02B3A4|!BankB
 
 .IsCustom
-    LDY $17AB|!Base2,x
+    LDY !shoot_timer,x
     BEQ .CallSprite
     PHA
     LDA $13
     LSR A
     BCC .NoDecTimer
-    DEC $17AB|!Base2,x
+    DEC !shoot_timer,x
 .NoDecTimer
     PLA
 .CallSprite

--- a/asm/minorextended.asm
+++ b/asm/minorextended.asm
@@ -18,7 +18,7 @@ Main:
     BCC .original
 
 .custom
-    SEC 
+    ;SEC 
     SBC.b #!MinorExtendedOffset     ; substract
     AND #$3F                        ; self imposed limit
     %CallSprite(Ptr)

--- a/asm/score.asm
+++ b/asm/score.asm
@@ -19,7 +19,7 @@ Main:
     BCC .original
 
 .custom
-    SEC 
+    ;SEC 
     SBC.b #!ScoreOffset
     AND #$1F
     %CallSprite(Ptr)

--- a/asm/smoke.asm
+++ b/asm/smoke.asm
@@ -19,7 +19,7 @@ Main:
     BCC .original
 
 .custom
-    SEC 
+    ;SEC 
     SBC.b #!SmokeOffset             ; substract
     AND #$1F                        ; self imposed limit
     %CallSprite(Ptr)

--- a/asm/spinningcoin.asm
+++ b/asm/spinningcoin.asm
@@ -28,7 +28,7 @@ Main:
     BCC .original
 
 .custom
-    SEC 
+    ;SEC 
     SBC.b #!SpinningCoinOffset      ; substract
     AND #$1F                        ; self imposed limit
     %CallSprite(Ptr)

--- a/routines/Bounce/GenericDraw.asm
+++ b/routines/Bounce/GenericDraw.asm
@@ -11,10 +11,10 @@
     %BounceGetDrawInfo()
     bcc ?.skip
     
+    rep #$20
     lda $00
     sta $0200|!addr,y
-    lda $01
-    sta $0201|!addr,y
+    sep #$20
     lda $02
     sta $0202|!addr,y
     lda !bounce_properties,x

--- a/routines/Bounce/GetDrawInfo.asm
+++ b/routines/Bounce/GetDrawInfo.asm
@@ -24,19 +24,19 @@
 ?.layer_1
     lda !bounce_x_low,x
     sec 
-    sbc.w $1A,y
+    sbc.w $1A|!dp,y
     sta $00
     lda !bounce_x_high,x
-    sbc.w $1B,y
+    sbc.w $1B|!dp,y
     beq ?.on_screen_x
     inc $03
 ?.on_screen_x
     lda !bounce_y_low,x
     sec 
-    sbc.w $1C,y
+    sbc.w $1C|!dp,y
     sta $01
     lda !bounce_y_high,x
-    sbc.w $1D,y
+    sbc.w $1D|!dp,y
     beq ?.on_screen_y
     clc
     rtl 

--- a/routines/CheckForContactAlternate.asm
+++ b/routines/CheckForContactAlternate.asm
@@ -19,7 +19,8 @@
     CMP $08
     BCC ?.checkXSub2
 ?.checkXSub1
-    SEC : SBC $08
+    ;SEC
+    SBC $08
     CMP $0C
     BCS ?.returnNoContact
     BRA ?.checkY
@@ -34,7 +35,8 @@
     CMP $0A
     BCC ?.checkYSub2
 ?.checkYSub1
-    SEC : SBC $0A
+    ;SEC
+    SBC $0A
     CMP $0E
     BCS ?.returnNoContact
 ?.returnContact

--- a/routines/ClusterGetDrawInfo.asm
+++ b/routines/ClusterGetDrawInfo.asm
@@ -1,6 +1,6 @@
-; Routine for minor extended sprites that fetches information to draw a single oam tile on screen.
+; Routine for cluster sprites that fetches information to draw a single oam tile on screen.
 ; It handles offscreen situations, including X position's high bit.
-; If a minor extended sprite is way too offscreen, the sprite will be erased from memory.
+; If a cluster sprite is way too offscreen, the sprite will be erased from memory.
 ;
 ; Input:
 ;   N/A

--- a/routines/MinorExtended/GetDrawInfo.asm
+++ b/routines/MinorExtended/GetDrawInfo.asm
@@ -22,8 +22,8 @@
     sta $01
     cmp #$E0
     bcc ?.check_x
-    clc 
-    adc #$10
+    ;clc 
+    adc #$0F ;adc #$10
     bpl ?.check_x
 ?.kill
     stz !minor_extended_num,x

--- a/routines/Score/GenericDraw.asm
+++ b/routines/Score/GenericDraw.asm
@@ -18,8 +18,8 @@
     bcc ?.return
     lda $00
     sta $0200|!addr,y
-    clc 
-    adc #$08
+    ;clc
+    adc #$07 ;adc #$08
     sta $0204|!addr,y 
     lda $01
     sta $0201|!addr,y

--- a/routines/Score/GetDrawInfo.asm
+++ b/routines/Score/GetDrawInfo.asm
@@ -20,11 +20,11 @@
     sta $02
     lda.w $1A|!dp,y
     sta $04
-    sep #$20
+    sep #$21
 
     lda !score_x_low,x
-    clc 
-    adc #$0C
+    ;clc 
+    adc #$0B ;adc #$0C
     php 
     sec 
     sbc $04

--- a/routines/SetPlayerClippingAlternate.asm
+++ b/routines/SetPlayerClippingAlternate.asm
@@ -11,9 +11,9 @@
 ?main:
 ?.SetPlayerClippingAlternate
     PHX
-    REP #$20
+    REP #$21
     LDA $94
-    CLC : ADC #$0002
+    ADC #$0002
     STA $00
     LDA #$000C
     STA $04
@@ -36,7 +36,7 @@
     LDA.l $03B65C|!bank,x
     REP #$20
     AND #$00FF
-    CLC : ADC $96
+    ADC $96
     STA $02
     SEP #$20
     PLX

--- a/routines/SetPlayerClippingAlternate.asm
+++ b/routines/SetPlayerClippingAlternate.asm
@@ -34,7 +34,7 @@
     STA $06
     STZ $07
     LDA.l $03B65C|!bank,x
-    REP #$20
+    REP #$21
     AND #$00FF
     ADC $96
     STA $02

--- a/routines/SetSpriteClippingAlternate.asm
+++ b/routines/SetSpriteClippingAlternate.asm
@@ -20,14 +20,14 @@
 ?.SetSpriteClippingAlternate
     LDA !sprite_x_high,x
     XBA : LDA !sprite_x_low,x
-    REP #$20
-    CLC : ADC $08
+    REP #$21
+    ADC $08
     STA $08
     SEP #$20
     LDA !sprite_y_high,x
     XBA : LDA !sprite_y_low,x
-    REP #$20
-    CLC : ADC $0A
+    REP #$21
+    ADC $0A
     STA $0A
     SEP #$20
     RTL

--- a/routines/Smoke/GenericDraw.asm
+++ b/routines/Smoke/GenericDraw.asm
@@ -18,7 +18,7 @@
     lda $00
     sta $0200|!addr,y
     lda $02
-    sta $0203|!addr,y
+    sta $0202|!addr,y
     sep #$20
     tya 
     lsr #2

--- a/routines/Smoke/GenericDraw.asm
+++ b/routines/Smoke/GenericDraw.asm
@@ -14,14 +14,12 @@
 ?main:
     %SmokeGetDrawInfo()
     bcc ?.return
+    rep #$20
     lda $00
     sta $0200|!addr,y
-    lda $01
-    sta $0201|!addr,y
     lda $02
-    sta $0202|!addr,y
-    lda $03
     sta $0203|!addr,y
+    sep #$20
     tya 
     lsr #2
     tay 

--- a/routines/SpinningCoin/GetDrawInfo.asm
+++ b/routines/SpinningCoin/GetDrawInfo.asm
@@ -1,4 +1,4 @@
-; Routine for bounce sprites that fetches information to draw a it on screen.
+; Routine for spinning coin sprites that fetches information to draw it on screen.
 ; It handles the offscreen bit and layer 2 offsets.
 ; 
 ; Input:


### PR DESCRIPTION
- asm/bounce.asm: removed redundant SEC (carry is already set there)
- asm/cluster.asm: removed redundant SEC, replaced constant #$09 with !ClusterOffset define and fixed init loop not resetting $1E02-$1E03 (since it doesn't loop back when X = 0)
- asm/extended.asm: removed redundant SEC
- asm/main.asm: removed redundant SEC and replaced shooter addresses with defines
- asm/minorextended.asm: removed redundant SEC
- asm/score.asm: removed redundant SEC
- asm/smoke.asm: removed redundant SEC
- asm/spinningcoin.asm: removed redundant SEC
- routines/Bounce/GenericDraw.asm: optimized OAM copy with 16 bit mode
- routines/Bounce/GetDrawInfo.asm: added |!dp to operations with absolute DP addresses for SA-1 compatibility
- routines/CheckForContactAlternate.asm: removed redundant SEC
- routines/ClusterGetDrawInfo.asm: fixed documentation
- routines/MinorExtended/GetDrawInfo.asm: replaced "clc : adc #$10" with "adc #$0F" (carry is set beforehand, so ADC adds 1)
- routines/Score/GenericDraw.asm: replaced "clc : adc #$08" with "adc #$07" (carry is set beforehand, so ADC adds 1)
- routines/Score/GetDrawInfo: replaced "sep #$20 : clc : adc #$0C" with "sep #$21 : adc #$0B" (set carry with SEP and ADC with -1)
- routines/SetPlayerClippingAlternate.asm: replaced "REP #$20 : CLC : ADC" with "REP #$21 : ADC" (clear carry with REP)
- routines/SetSpriteClippingAlternate.asm: replaced "REP #$20 : CLC : ADC" with "REP #$21 : ADC" (clear carry with REP)
- routines/Smoke/GenericDraw.asm: optimized OAM copy with 16 bit mode
- routines/SpinningCoin/GetDrawInfo.asm: fixed documentation