### PR TITLE
CFG Editor: fix resizing clipping images (e.g. sprite clipping 0x33)

### DIFF
--- a/src/CFG Editor/CFG Editor/CFG Editor.cs
+++ b/src/CFG Editor/CFG Editor/CFG Editor.cs
@@ -676,14 +676,14 @@ namespace CFG
                 height = size.Height;
                 width = (height / img.Height) * img.Width;
                 y = 0;
-                x = (size.Width / 2) - (width / 2);
+                x = (float)Math.Floor((size.Width / 2) - (width / 2));
             }
             else
             {
                 width = size.Width;
                 height = (width / img.Width) * img.Height;
                 x = 0;
-                y = (size.Height / 2) - (height / 2);
+                y = (float)Math.Floor((size.Height / 2) - (height / 2));
             }
 
             Bitmap bm = new Bitmap(size.Width, size.Height);


### PR DESCRIPTION
Previous image resize lost the red interaction points:

![image](https://github.com/JackTheSpades/SpriteToolSuperDelux/assets/88097699/3be223e9-2a26-4992-8330-adc23d7eb814)
