### PR TITLE
!bounce_table holds layer 1/2 information

### DIFF
--- a/routines/Bounce/GetDrawInfo.asm
+++ b/routines/Bounce/GetDrawInfo.asm
@@ -17,7 +17,7 @@
     lda #$02
     sta $03
     ldy #$00
-    lda !bounce_properties,x
+    lda !bounce_table,x
     bpl ?.layer_1
 ?.layer_2
     ldy #$04

--- a/routines/Bounce/SetupMap16.asm
+++ b/routines/Bounce/SetupMap16.asm
@@ -17,7 +17,7 @@
     lda !bounce_x_high,x
     adc #$00
     sta $9B
-    lda !bounce_properties,x
+    lda !bounce_table,x
     asl
     rol
     and #$01


### PR DESCRIPTION
Fixes layer 2 bounce sprites using wrong render position and wrong layer when changing back into block