### PR TITLE
Have FireballContact routine check exactly for player fireball value

### DIFF
--- a/routines/FireballContact.asm
+++ b/routines/FireballContact.asm
@@ -20,7 +20,8 @@
     PHX                             ; Preserve X.
     LDY #$00                        ; Set initial fireball index.
 ?-   LDA !extended_num+8,y           ; If there is no fireball in this slot,
-    BEQ ?.nothing                    ; check the next one.
+    CMP #$05
+    BNE ?.nothing                    ; check the next one.
     LDA !extended_x_low+8,y         ; Store clipping B of fireball.
     SEC : SBC #$02
     STA $00


### PR DESCRIPTION
Currently, the `FireballContact` routine only checks whether one of the two fireball slots is empty or not to determine if a collision check is required.

However, a problem arises when contact is detected and trying to replace the fireball with a puff of smoke that disappears after some frames
```asm
%FireballContact()                      ; If there is no contact,
BCC .no_contact                         ; then return

; Replace fireball with puff of smoke, similar to what the original game
; does at $02A045.
LDA #$01 : STA $1DF9|!addr              ; Play sound effect
LDA #$01 : STA !extended_num+8,y        ; Turn fireball into smoke
LDA #$0F : STA $176F+8|!addr,y          ; Set timer for erasing smoke

; ...

.no_contact
; ...
```

In this case, the next frame the contact check will pass again, because `!extended_num+8,y` is 1 (puff of smoke) and not 0. If, for instance, the fireball is supposed to remove 1 HP from a sprite and then disappear, it will remove 16 ($0F) instead.

The current solution is either to not spawn the puff of smoke and make the fireball disappear (not pretty), or to spawn the puff of smoke in another extended slot (not practical).

The change in this PR makes it so that the routine checks contact for fireball slots if and only if the stored value is 5 (player fireball).