### PR TITLE
Sprite Status 3 Custom Graphics Handler

### DIFF
--- a/asm/main.asm
+++ b/asm/main.asm
@@ -170,8 +170,13 @@ org $02A9A6|!BankB
 ; I wasn't sure where to put this new hijack
 ; so it lives here now, I guess.
 ; (By SubconsciousEye)
-org $019AFE|!BankB
-    JML Status3GfxHandler
+if !SA1 == 0
+    org $019AFE|!BankB
+        JML Status3GfxHandler
+else
+    org $019B00|!BankB
+        JML Status3GfxHandler
+endif
 
 ; The following two hijacks here are to fix
 ; two sprites' squished graphics because

--- a/asm/main.asm
+++ b/asm/main.asm
@@ -1169,8 +1169,6 @@ SubHandleStatus:
     PLA                            ;sprite status
     CMP #$09
     BCS CallMain2                ;restored for backwards compatibility with sprites
-    CMP #$03                    ;run main for state 03 (smushed)
-    BEQ CallMain2
     JML $0185C2|!BankB        ;goto RTL
 CallMain2:
     PHA


### PR DESCRIPTION
This was intended to be made earlier, but IRL events pushed it some weeks.

## Preamble
In Vanilla SMW, Statuses 2 and 5 (Falling and Lava Deaths respectively) both run a subroutine that handles death graphics for the given sprite. A special condition at the start of the routine checks for bit 0 of the !167A table (AND #$01), and if it's set, it runs the sprite's Main (Status 8) routine to handle graphics instead of the generic routine. This very behavior is also what allows custom sprites to show proper GFX in the case it ends up dying.

Sprite Status 3 (Smushed) does not have this aforementioned check, so PIXI (and maybe older Sprite Tools, haven't checked too much) has a special case for custom sprites. This special case essentially just runs Sprite Main after running Status 3 code for Custom Sprites, regardless of the unique !extra_prop_2 status override property (specifically bit 6, as bit 7 will always call the Main Status if it's set).

Normally, the enforced "Call Sprite Main" code works well for custom sprites, but there is one minor oversight where !14C8 is zeroed in the Status 3 routine and be desynced from its stack backup, which is used for the Status check to call the Sprite's Main routine. This oversight can cause some unintended side effects if a sprite doesn't take it into account or expect it.

What this Pull Request does is implement a Custom Graphics Handler for Status 3 utilizing !167A, and hopefully deprecates the old system.

## Pre-Testing Notes
There are some sprites in SMW, such as the P-Switch and Rex, that don't actually use Status 3, but instead "spoof" it through their main code. Interestingly, the P-Switch *does* call Status 3's Generic GFX Handler, but doesn't actually use said status under normal circumstances. Given these cases and how some Custom Sprites also utilize this same tactic, such sprites are not included in testing.

SMW's Koopas (Sprite 04-07) have an unusual interaction where if the player lands on a Koopa while in cape flight, the Koopa will become "Squished" and show garbage graphics. Technically, these graphics are the default for any sprite that isn't checked, but a Custom JSON that acts as a "Tweaked" Koopa is included for ease of testing.
Additionally, the Generic Graphics Handler for the Squished Status contains a check for SMW's Goomba (Sprite 0F), so a Custom JSON that acts as a "Tweaked" Goomba is included in the ZIP.

Both SMW's Dino Torch (Sprite 6F) and Sliding Beach Koopa (Sprite BD) *do* set bit 0 of !167A for death graphics, but still use some of the original SMW Status 3 code for getting graphics. As a result, these two sprites needed to be fixed in order to properly show their smushed pose when needed. The Dino Torch in particular uses a 16x16 for its squashed pose.

I created a special "Test" sprite to test the different methods of Custom Squished Graphics, both the old PIXI method and this new approach. Setting the Extra Bit for this Test Sprite will make it use a Fail-Safe for the old method, and clearing the Extra Bit will not utilize this Fail-Safe (thus "resetting" the sprite in the old method). Simply just walk up to the sprite to "squish" it.

I wasn't sure where to place the new code within main.asm, so I opted to slot them near the end of common hijacks/hexedits and near the end of most custom PIXI code. Additionally, I kept the formatting consistent with 90% of the other codes inside main.asm. Feel free to let me know or change as you see fit.

## Testing
Since there are so few sprites (both custom and vanilla) that can actually be put into Status 3 under normal circumstances, this test isn't very comprehensive. However, seeing as this is a test to ensure that these sprites can run properly without any additional modifications, this shouldn't affect results too much. Only (Fast) LoROM has been tested thus far, but it should work well with SA-1 assuming little-to-no edits to the ASM.

The list of tested sprites are as follows:
- SMW's Beach Koopa (00-03)
- SMW's Dino Torch (6F)
- SMW's Sliding Beach Koopa (BD)
- Tweaked SMW Koopa (04, different palette)
- Tweaked SMW Goomba (0F, different palette)
- [Thomas's Beach Koopa Disassembly](https://smwc.me/s/13892)
- [yoshicookiezeus's Sliding Koopa Disassembly](https://smwc.me/s/3487) (slight issue with gfx code, but otherwise runs)
- [Sonikku's SMB3 Goomba Family](https://smwc.me/s/23199) (only the non-winged variant)
- [Thomas's Sleepy Goomba](https://smwc.me/s/24079)
- Custom Status 3 Test Sprite

The Tweaked and Test Sprites can be found in this [ZIP](https://github.com/JackTheSpades/SpriteToolSuperDelux/files/13047696/Status3TestingSprites.zip), just insert them into any custom sprite slot.

This test was done with both the old PIXI method, and this new proposed method. No adverse effects were found when utilizing the new approach, as every sprite ran their smushed status without any hindrance.

## Alternate Approaches
Prior to the current approach this Pull Request is based on, I had considered other methodologies. I didn't opt for these alternatives since one would require Custom Sprites to update/fix their Acts Like, while another involves a lot of stack shenanigans to fix the affected Vanilla Sprites.

I believe this current implementation offers a nice middle-ground in terms of readability and code-size while also ensuring minimal edits and changes done to both sides. Please let me know if you believe one of the other alternative approaches better suits PIXI or if any (additional) concerns should be addressed.