### PR TITLE
Fix address of OAM indices of MinorExtendedGetDrawInfo

### DIFF
--- a/routines/MinorExtended/GetDrawInfo.asm
+++ b/routines/MinorExtended/GetDrawInfo.asm
@@ -47,7 +47,7 @@
     bcs ?.kill
     inc $02
 ?.on_screen_x
-    lda.l $028B77|!BankB,x
+    lda.l $028B78|!BankB,x
     tay
     sec 
     rtl


### PR DESCRIPTION
Basically, MinorExtendedGetDrawInfo is currently broken in that the address to the OAM indices is one byte short: The table actually starts at $028B78, not at $028B77.