### PR TITLE
Add command line flags for custom misc sprites directories in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,11 @@ The changelog is available [here](CHANGELOG.md).
   -g  <generators>        Specify a custom generators directory (Default generators/)
   -e  <extended>  Specify a custom extended sprites directory (Default extended/)
   -c  <cluster>   Specify a custom cluster sprites directory (Default cluster/)
+  -b  <bounce>    Specify a custom bounce sprites directory (Default misc_sprites/bounce/)
+  -me <minorextended>     Specify a custom minor extended sprites directory (Default misc_sprites/minorextended/)
+  -sc <score>     Specify a custom score sprites directory (Default misc_sprites/score/)
+  -sm <smoke>     Specify a custom smoke sprites directory (Default misc_sprites/smoke/)
+  -sn <spinningcoin>      Specify a custom spinning coin sprites directory (Default misc_sprites/spinningcoin/)
 
   -r  <sharedpath>        Specify a shared routine directory (Default routines/)
   -nr <number>			Specify a maximum number of shared routines (Default is 100, maximum is 310)


### PR DESCRIPTION
Document the flags that allow to specify custom directories for misc sprites (minor extended, bounce, etc.).

This is kind of a niche feature (I guess not many people will need it), but I had to dig in the repo's code to find it.