### PR TITLE
Change labels in %invoke_snes() to be macro-local

### DIFF
--- a/asm/sa1def.asm
+++ b/asm/sa1def.asm
@@ -51,8 +51,8 @@ macro invoke_snes(addr)
 	STA $0185
 	LDA #$D0
 	STA $2209
--	LDA $018A
-	BEQ -
+?-	LDA $018A
+	BEQ ?-
 	STZ $018A
 endmacro
 


### PR DESCRIPTION
As is, it has the potential to interfere with `-` near any uses of this; alerted to this by Skewer.